### PR TITLE
Escape Node Names in Messages

### DIFF
--- a/dev/pgf-umlsd.sty
+++ b/dev/pgf-umlsd.sty
@@ -39,7 +39,7 @@
 \ProvidesPackage{pgf-umlsd}[2011/07/27 v0.6 Some LaTeX macros for UML
 Sequence Diagrams.]
 
-\RequirePackage{tikz}
+\RequirePackage{tikz, xstring}
 \usetikzlibrary{arrows,shadows}
 
 \RequirePackage{ifthen}
@@ -252,8 +252,13 @@ node
   \draw[->,>=angle 60] (mess from) -- (mess to) node[midway, above]
   {#3};
 
-  \node (#3 from) at (mess from) {};
-  \node (#3 to) at (mess to) {};
+  \StrSubstitute{#3}{(}{*}[\messName]
+  \StrSubstitute{\messName}{)}{*}[\messName]
+  \StrSubstitute{\messName}{,}{*}[\messName]
+  \StrSubstitute{\messName}{;}{*}[\messName]
+
+  \node (\messName from) at (mess from) {};
+  \node (\messName to) at (mess to) {};
 }
 
 \newenvironment{messcall}[4][1]{


### PR DESCRIPTION
The \mess macro uses the text of the
message between nodes to create a node for later annotations. If the
text contains a parentheses or other special TikZ character, the
document will fail to compile.

This update uses the xstring package to replace all special characters
in the text of the message with "*", so the node is still created but
with a legal name.