### PR TITLE
Fix: Prevent new line indent

### DIFF
--- a/dev/pgf-umlsd.sty
+++ b/dev/pgf-umlsd.sty
@@ -331,10 +331,10 @@ node
 % the environment of sequence diagram
 \newenvironment{sequencediagram}{
   % declare layers
-  \pgfdeclarelayer{umlsd@background}
-  \pgfdeclarelayer{umlsd@threadlayer}
-  \pgfsetlayers{umlsd@background,umlsd@threadlayer,main}
-
+  \pgfdeclarelayer{umlsd@background}% Necessary comment to prevent indent
+  \pgfdeclarelayer{umlsd@threadlayer}% Necessary comment to prevent indent
+  \pgfsetlayers{umlsd@background,umlsd@threadlayer,main}% Necessary comment to prevent indent
+% Necessary comment to prevent indent
   \begin{tikzpicture}
     \setlength{\unitlength}{1cm}
     \tikzstyle{sequence}=[coordinate]


### PR DESCRIPTION
Added comments (%) within the environment definition of `sequencediagram` in order to prevent indents.